### PR TITLE
Fix link to non SSL PDF readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Generate a Bip39 Wallet Mnemonic using plain six sided dice and a coin
 
 Print Friendly verison:
-http://github.com/taelfrinn/Bip39-diceware/raw/master/coin_plus_d6_bip39.pdf
+https://github.com/taelfrinn/Bip39-diceware/raw/master/coin_plus_d6_bip39.pdf
 
 
 


### PR DESCRIPTION
Linking to non SSL PDFs from SSLed pages doesn't work in Chrome.